### PR TITLE
Adding a debounce function for the TOF sensor

### DIFF
--- a/homeassistant/esphome/stair-motion-botom-tof.yaml
+++ b/homeassistant/esphome/stair-motion-botom-tof.yaml
@@ -66,13 +66,19 @@ sensor:
            * '0.5' meters is about 20  inches.
            */
           static double minTripDistance = 0.7;
+          // Adding a debouncing counter. Increases with every update_interval during the debouncing period
+          static int deBounce = 0;
           if (x <= minTripDistance) {
             if (id(breakbeam_sensor_bottom).state == true) {
               // Beam was already broken
+              // Increase the debouncing counter
+              deBounce++;
               return {};
             }
             // Beam was just broken
             id(breakbeam_sensor_bottom).publish_state(true);
+            // Reset the debouncing counter
+            deBounce = 0;
             ESP_LOGI("breakbeam_sensor_bottom_dist", "Set breakbeam_sensor_bottom to Detected");
             return {};
           }
@@ -82,6 +88,13 @@ sensor:
               return {};
             }
             // Beam was just un-broken
+            // Don't do anything during the deboucing period. A debouncing threshold of 10 means that it will take 10 * update_interval before the binary sensor will be cleared
+            // Change the value to anything that will prevent your sensor from resetting to early
+            if (deBounce < 10)
+            {
+              deBounce++;
+              return {};
+            }
             id(breakbeam_sensor_bottom).publish_state(false);
             ESP_LOGI("breakbeam_sensor_bottom_dist", "Set breakbeam_sensor_bottom to Cleared");
             return {};

--- a/homeassistant/esphome/stair-motion-top-tof.yaml
+++ b/homeassistant/esphome/stair-motion-top-tof.yaml
@@ -67,13 +67,19 @@ sensor:
            * '0.5' meters is about 20  inches.
            */
           static double minTripDistance = 0.55;
+          // Adding a debouncing counter. Increases with every update_interval during the debouncing period
+          static int deBounce = 0;
           if (x <= minTripDistance) {
             if (id(breakbeam_sensor_top).state == true) {
               // Beam was already broken
+               // Increase the debouncing counter
+              deBounce++;
               return {};
             }
             // Beam was just broken
             id(breakbeam_sensor_top).publish_state(true);
+            // Reset the debouncing counter
+            deBounce = 0;
             ESP_LOGI("breakbeam_sensor_top_dist", "Set breakbeam_sensor_top to Detected");
             return {};
           }
@@ -83,6 +89,13 @@ sensor:
               return {};
             }
             // Beam was just un-broken
+            // Don't do anything during the deboucing period. A debouncing threshold of 10 means that it will take 10 * update_interval before the binary sensor will be cleared
+            // Change the value to anything that will prevent your sensor from resetting to early
+            if (deBounce < 10)
+            {
+              deBounce++;
+              return {};
+            }
             id(breakbeam_sensor_top).publish_state(false);
             ESP_LOGI("breakbeam_sensor_top_dist", "Set breakbeam_sensor_top to Cleared");
             return {};


### PR DESCRIPTION
Hi,

Thanks for making your code public. I used it to create my own stairlight, but the ToF sensors were a little too sensitive in my setup, it sometimes triggered a number of breakbeam and breakbeam-clear events directly after each other when passing the sensor. So I decided to incorporate a small 'debouncing' function in the lambda-function. In this case I have an update interval of 0.1 second and a debouncing threshold of 10 (10 * 0.1s = 1 s), meaning that after the beam has been broken every new reading within 1 second after that will simply be ignored. This kept my automation from 'bouncing' around.
I hope you may see the benefit of this and will include it in your code.

//Rob 